### PR TITLE
Stereo_camera_node: Synchronize timestamp for /camera_info topics and /image topics

### DIFF
--- a/src/stereo_camera_node.cpp
+++ b/src/stereo_camera_node.cpp
@@ -168,6 +168,11 @@ int main(int argc, char **argv) {
                      timestamp);
       pub_left.publish(image_msg_left);
       pub_right.publish(image_msg_right);
+
+      // Publish camera info
+      camera_calib_msg_left.header = image_msg_left->header;
+      camera_calib_msg_right.header = image_msg_right->header;
+
       pub_left_cam_info.publish(camera_calib_msg_left);
       pub_right_cam_info.publish(camera_calib_msg_right);
     }


### PR DESCRIPTION
As described in the name. Previously the timestamps of `/camera_info` topics are not in synced with the image topics. This causes error if other applications want to use both topics, i.e.:
```
[image_transport] Topics '/pirvs_cam_raw/StereoImage/left' and /pirvs_cam_raw/StereoImage/left/camera_info' do not appear to be synchronized
```
Hope this helps.